### PR TITLE
Enable deque bump for latest/stackage

### DIFF
--- a/butcher.cabal
+++ b/butcher.cabal
@@ -50,7 +50,7 @@ library
     , extra <1.7
     , void <0.8
     , bifunctors <5.6
-    , deque >=0.2.4 && <0.3
+    , deque >=0.2.4 && <0.5
     }
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/butcher.cabal
+++ b/butcher.cabal
@@ -1,5 +1,5 @@
 name:                butcher
-version:             1.3.2.1
+version:             1.3.2.2
 synopsis:            Chops a command or program invocation into digestable pieces.
 description:         See the <https://github.com/lspitzner/butcher/blob/master/README.md README> (it is properly formatted on github).
 license:             BSD3

--- a/srcinc/prelude.inc
+++ b/srcinc/prelude.inc
@@ -128,9 +128,15 @@ import Data.Semigroup ( Semigroup(..) )
 import Data.Map ( Map )
 import Data.Set ( Set )
 
+#if MIN_VERSION_base(0,4,0)
+import Deque.Lazy ( Deque )
+
+import qualified Deque.Lazy as Deque
+#else
 import Deque ( Deque )
 
 import qualified Deque
+#endif
 
 import Prelude                            ( Char
                                           , String

--- a/srcinc/prelude.inc
+++ b/srcinc/prelude.inc
@@ -128,7 +128,7 @@ import Data.Semigroup ( Semigroup(..) )
 import Data.Map ( Map )
 import Data.Set ( Set )
 
-#if MIN_VERSION_base(0,4,0)
+#if MIN_VERSION_deque(0,3,0)
 import Deque.Lazy ( Deque )
 
 import qualified Deque.Lazy as Deque


### PR DESCRIPTION
Wanting to get butcher compiling with Stackage nightly. The Deque package added a Deque.Strict variant and renamed the original Deque module to Deque.Lazy @0.3.0. Added Cabal conditional directive to use new module name when Deque is >=3.