### PR TITLE
Support for base-4.15 and ghc-9.0.*

### DIFF
--- a/butcher.cabal
+++ b/butcher.cabal
@@ -37,7 +37,7 @@ library
   other-modules:       UI.Butcher.Monadic.Internal.Types
                        UI.Butcher.Monadic.Internal.Core
   build-depends:
-    { base >=4.11 && <4.16
+    { base >=4.11 && <4.17
     , free < 5.2
     , unsafe < 0.1
     , microlens <0.5

--- a/butcher.cabal
+++ b/butcher.cabal
@@ -37,7 +37,7 @@ library
   other-modules:       UI.Butcher.Monadic.Internal.Types
                        UI.Butcher.Monadic.Internal.Core
   build-depends:
-    { base >=4.11 && <4.15
+    { base >=4.11 && <4.16
     , free < 5.2
     , unsafe < 0.1
     , microlens <0.5
@@ -109,7 +109,7 @@ test-suite tests
     }
   ghc-options:      -Wall -rtsopts
   main-is:          TestMain.hs
-  other-modules:    
+  other-modules:
   hs-source-dirs:   src-tests
   include-dirs:
     srcinc

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,0 @@
-packages: .
-
-allow-newer:
-  multistate:base

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages: .
+
+allow-newer:
+  multistate:base


### PR DESCRIPTION
* This needs https://github.com/lspitzner/multistate/pull/8
* The auxiliary cabal.project could be dropped then
* This is needed for allow the haskell-language-server brittany plugin for ghc-9.0.1 in hackage.
* Closes #7 

//cc @lspitzner thanks in advance!